### PR TITLE
Rename _init method (reserved by vue 2.4.3);

### DIFF
--- a/src/VueHighcharts.vue
+++ b/src/VueHighcharts.vue
@@ -17,7 +17,7 @@
     },
     mounted(){
       if (!this.getChart() && this.options) {
-        this._init();
+        this.init();
       }
     },
 
@@ -50,7 +50,7 @@
         return this.getChart()[name](...args)
       },
 
-      _init(){
+      init(){
         if (!this.getChart() && this.options) {
          let _Highcharts = this.Highcharts || Highcharts;
          if (_Highcharts.product == 'Highstock') {
@@ -65,7 +65,7 @@
     watch: {
       options: function (options) {
         if (!this.getChart() && options) {
-          this._init()
+          this.init()
         } else {
           this.getChart().update(this.options);
         }


### PR DESCRIPTION
Rename _init method (reserved by vue 2.4.3);
Avoid warn message. _ and $ methods in components going to be reserved by vue core.

https://github.com/vuejs/vue/commit/8fc6bc882708a725693b50a55f56cfde653ee48d#diff-cb87aa7890fa694dd923ea9f162256d2

Thanks!