### PR TITLE
Align with best practices for production component

### DIFF
--- a/src/VueHighcharts.vue
+++ b/src/VueHighcharts.vue
@@ -23,7 +23,7 @@ export default {
       }
     },
     options: Object,
-    Highcharts: Object,
+    highcharts: Object,
   },
   name: 'VueHighcharts',
   data() {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -44,7 +44,7 @@ var base = {
   performance: {
     hints: false
   },
-  devtool: '#eval-source-map',
+  devtool: process.env.NODE_ENV === 'production' ? '' : '#eval-source-map',
   plugins: [
 
   ],
@@ -52,5 +52,3 @@ var base = {
 
 
 module.exports = base;
-
-


### PR DESCRIPTION
1. Vue community has implemented lower case props as the standard for props with dashes. It is enforced by eslint vue plugin. So I changed Highchart to highchart for the props

2. Remove sourcemaps for production builds to comply with CSP best practice of not using eval. Also, reduces size of included component  in others codebase.
